### PR TITLE
Humble+CycloneDDS config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ros:iron-ros-core
+FROM ros:humble-ros-core
 
 RUN apt update && apt install -y \
-        ros-${ROS_DISTRO}-demo-nodes-cpp && \
+        ros-${ROS_DISTRO}-demo-nodes-cpp \
+        ros-${ROS_DISTRO}-rmw-cyclonedds-cpp && \
     rm -rf /var/lib/apt/lists/*
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -21,6 +21,7 @@ services:
     volumes:
       - ./filter.yaml:/filter.yaml
     environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
       - PARTICIPANTS=husarnet,if-eth0 # eth0 -is the name of the network interface from a Docker network in the container
 
   husarnet:

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,10 +3,14 @@ services:
   add_two_ints:
     build: .
     restart: unless-stopped
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
     command: ros2 run demo_nodes_cpp add_two_ints_${ADD_TWO_INTS_ROLE:-server}
 
   chatter:
     build: .
+    environment:
+      - RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
     command: ros2 run demo_nodes_cpp ${CHATTER_ROLE:-listener}
 
   ros2router:


### PR DESCRIPTION
Change the default iron + fastrtps config to humble + cyclonedds. 

This causes the example to no longer work, that is no communication is possible via the cyclonedds and running humble containers. 